### PR TITLE
Remove redundant URL file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ Start the Flask server:
 python app.py
 ```
 
-Open `http://localhost:5000` in your browser and click **Start Jupyter Notebook**. The server starts a container in the background, waits for the Jupyter Lab token, and then redirects your browser to the running notebook.
-
-The tokenised URL is also stored in `jupyter_url.json` so that it can be retrieved by the web page.
+Open `http://localhost:5000` in your browser and click **Start Jupyter Notebook**. The server starts a container in the background, waits for the Jupyter Lab token, and automatically redirects your browser to the running notebook once it is ready.
 
 ## Customisation
 


### PR DESCRIPTION
## Summary
- stop writing the Jupyter URL to `jupyter_url.json`
- store the URL in memory instead
- update README accordingly

## Testing
- `python -m py_compile app.py container_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_685adfc2b7548333844ff4a878b73e7e