### PR TITLE
Switch to gunicorn and track sessions in SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+sessions.db
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -19,15 +19,13 @@ pip install -r requirements.txt
 
 ## Running
 
-Start the Flask server:
+Start the application using gunicorn:
 
 ```bash
-python app.py
+gunicorn -w 4 -b 0.0.0.0:8000 app:app
 ```
 
-Open `http://localhost:5000` in your browser and click **Start Jupyter Notebook**. The server creates a Kubernetes pod in the background, waits for the Jupyter Lab token, and then redirects your browser to the running notebook.
-
-The tokenised URL is also stored in `jupyter_url.json` so that it can be retrieved by the web page.
+Open `http://localhost:8000` in your browser. The web interface automatically begins launching a notebook pod. Each request is assigned a session ID that is stored in a local SQLite database. The page polls the API with this ID until the Jupyter server is ready and then redirects your browser to the running instance.
 
 ## Customisation
 

--- a/app.py
+++ b/app.py
@@ -1,58 +1,79 @@
-from flask import Flask, render_template, jsonify
+from flask import Flask, render_template, jsonify, request
 from container_manager import start_pod_and_get_jupyter_url
 import threading
-import json
-import os
-from urllib.parse import urlparse
+import sqlite3
+import uuid
 
 app = Flask(__name__)
 
-URL_FILE = "jupyter_url.json"
+DB_PATH = "sessions.db"
 
-def save_url_to_file(url):
-    with open(URL_FILE, "w") as f:
-        json.dump({"url": url}, f)
 
-def load_url_from_file():
-    if os.path.exists(URL_FILE):
-        with open(URL_FILE, "r") as f:
-            data = json.load(f)
-            return data.get("url")
-    return None
+def init_db():
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS sessions (session_id TEXT PRIMARY KEY, url TEXT)"
+        )
 
-def launch_container():
+
+def create_session(session_id: str):
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "INSERT INTO sessions(session_id, url) VALUES (?, NULL)", (session_id,)
+        )
+
+
+def update_session_url(session_id: str, url: str):
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "UPDATE sessions SET url = ? WHERE session_id = ?", (url, session_id)
+        )
+
+
+def get_session_url(session_id: str) -> str | None:
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.execute(
+            "SELECT url FROM sessions WHERE session_id = ?", (session_id,)
+        )
+        row = cur.fetchone()
+        return row[0] if row else None
+
+
+def launch_container(session_id: str):
     jupyter_url = start_pod_and_get_jupyter_url()
     if jupyter_url:
-        save_url_to_file(jupyter_url)
+        update_session_url(session_id, jupyter_url)
 
 
-@app.route('/no_gpu')
+@app.route("/no_gpu")
 def no_gpu():
     """Inform the user that no GPUs are currently available."""
-    return render_template('gpu_unavailable.html')
+    return render_template("gpu_unavailable.html")
 
-@app.route('/')
+
+@app.route("/")
 def home():
-    return render_template('index.html')
+    return render_template("index.html")
 
-@app.route('/launch', methods=['POST'])
+
+@app.route("/launch", methods=["POST"])
 def launch():
-    # Remove any previous URL before launching
-    if os.path.exists(URL_FILE):
-        os.remove(URL_FILE)
-    # Start the container in a background thread
-    thread = threading.Thread(target=launch_container)
+    session_id = str(uuid.uuid4())
+    create_session(session_id)
+    thread = threading.Thread(target=launch_container, args=(session_id,))
     thread.start()
-    return jsonify({"message": "Pod is launching, please wait..."})
+    return jsonify(
+        {"message": "Pod is launching, please wait...", "session_id": session_id}
+    )
 
-@app.route('/get_url', methods=['GET'])
+
+@app.route("/get_url", methods=["GET"])
 def get_url():
-    url = load_url_from_file()
+    session_id = request.args.get("session_id")
+    url = get_session_url(session_id) if session_id else None
+    return jsonify({"url": url})
 
-    return jsonify({
-        "url": url,
-        
-    })
 
-if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0', port=5000)
+if __name__ == "__main__":
+    init_db()
+    app.run(debug=True, host="0.0.0.0", port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 flask
 kubernetes
+
+gunicorn

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -16,10 +16,12 @@ document.addEventListener('DOMContentLoaded', () => {
       progressBar.innerText = '0%';
   
       // Start the container launch process
+      let sessionId = null;
       fetch('/launch', { method: 'POST' })
           .then(response => response.json())
           .then(data => {
               console.log(data.message);
+              sessionId = data.session_id;
               // Start polling for the Jupyter URL and simulate progress
               pollForUrl();
               simulateProgress();
@@ -41,8 +43,9 @@ document.addEventListener('DOMContentLoaded', () => {
   
       // Poll for the Jupyter URL every 2000ms
       function pollForUrl() {
+          if (!sessionId) return;
           console.log('Polling for Jupyter URL...');
-          fetch('/get_url', { method: 'GET' })
+          fetch(`/get_url?session_id=${sessionId}`, { method: 'GET' })
               .then(response => response.json())
               .then(data => {
                   if (data.url) {
@@ -60,4 +63,4 @@ document.addEventListener('DOMContentLoaded', () => {
               .catch(error => console.error('Error:', error));
       }
   }
-  
+


### PR DESCRIPTION
## Summary
- use gunicorn to run the webserver
- drop json URL file and store session ids in a lightweight SQLite DB
- adjust JS to pass a session id when polling
- document the new gunicorn command and behaviour in README
- ignore generated database file in git

## Testing
- `python -m py_compile app.py container_manager.py`
- `pip install --disable-pip-version-check -r requirements.txt` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687ff2bf986c83338e0fbcddfc5a42ba